### PR TITLE
Keep app alive if plugged-in

### DIFF
--- a/Patriot/AppDelegate.swift
+++ b/Patriot/AppDelegate.swift
@@ -17,8 +17,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    
+        disableSleepWhilePluggedIn()
         
         return true
+    }
+    
+    
+    func disableSleepWhilePluggedIn()
+    {
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        if UIDevice.current.batteryState != .unplugged
+        {
+            UIApplication.shared.isIdleTimerDisabled = true
+        }
     }
 }
 


### PR DESCRIPTION
Keep app alive when running and device is plugged in. This is important for "mounted to the wall" operation.